### PR TITLE
add HTTPS and short URLs support to Amazon

### DIFF
--- a/lib/Noembed/Provider/Amazon.pm
+++ b/lib/Noembed/Provider/Amazon.pm
@@ -18,15 +18,19 @@ sub prepare_provider {
 }
 
 sub provider_name { "Amazon" }
+sub shorturls {
+  'https?://a\.co/[^/]+',
+  'https?://amzn\.to/[^/]+',
+}
 sub patterns {
-  'http://www\.amazon\.com/(?:.+/)?[gd]p/(?:product/)?(?:tags-on-product/)?([a-zA-Z0-9]+)',
-  'http://amzn\.com/([^/]+)'
+  'https?://(?:www\.)?amazon\.com/(?:.+/)?[gd]p/(?:product/)?(?:tags-on-product/)?([a-zA-Z0-9]+)',
+  'https?://amzn\.com/(?:[gd]p/)?([^/]+)',
 }
 
 sub build_url {
   my ($self, $req) = @_;
   my $asin = $req->captures->[0];
-  my $u = URI::Amazon::APA->new('http://webservices.amazon.com/onca/xml');
+  my $u = URI::Amazon::APA->new('https://webservices.amazon.com/onca/xml');
   $u->query_form(
     Service => 'AWSECommerceService',
     AssociateTag => 'usealiceorg-20',


### PR DESCRIPTION
Amazon's default access protocol is HTTPS now. All HTTP access redirected to HTTPS.

Add support two short urls, `a.co` and `amzn.to`. You can get the first one from the share button of a product page, and the latter one is generated by `bit.ly`.

Modify two regexes from `www\.amazon\.com/` to `(?:www\.)?amazon\.com/` and from `amzn\.com/([^/]+)` to `amzn\.com/(?:[gd]p/)?([^/]+)` to support other url variations.